### PR TITLE
【大改进】

### DIFF
--- a/HUPhotoBrowser/HUPhotoBrowser.h
+++ b/HUPhotoBrowser/HUPhotoBrowser.h
@@ -11,6 +11,10 @@
 
 typedef void(^ __nullable DismissBlock)(UIImage * __nullable image, NSInteger index);
 
+typedef void(^ __nullable DidSaveBlock)(UIImage * image, NSError * error, void * contextInfo);
+
+typedef void(^ __nullable LongTapBlock)(UIImage * image, NSInteger index,UILongPressGestureRecognizer *longGesture);
+
 @interface HUPhotoBrowser : UIView
 
 @property (nonatomic, strong, readonly) UIButton *saveButton;
@@ -54,6 +58,62 @@ typedef void(^ __nullable DismissBlock)(UIImage * __nullable image, NSInteger in
  */
 + (nonnull instancetype)showFromImageView:(nullable UIImageView *)imageView withImages:(nullable NSArray *)images atIndex:(NSInteger)index dismiss:(DismissBlock)block;
 
+/*
+ * @param imageView    点击的imageView
+ * @param URLStrings   加载的网络图片的urlString
+ * @param image        占位图片
+ * @param index        点击的图片在所有要展示图片中的位置
+ * @param didSave      photo保存到m相册的回调
+ */
++ (nonnull instancetype)showFromImageView:(nullable UIImageView *)imageView withURLStrings:(nullable NSArray *)URLStrings placeholderImage:(nullable UIImage *)image atIndex:(NSInteger)index didSave:(DidSaveBlock)saveBlock;
+
+/*
+ * @param imageView    点击的imageView
+ * @param withImages   加载的本地图片
+ * @param image        占位图片
+ * @param index        点击的图片在所有要展示图片中的位置
+ * @param didSave      photo保存到m相册的回调
+ */
++ (nonnull instancetype)showFromImageView:(nullable UIImageView *)imageView withImages:(nullable NSArray *)images atIndex:(NSInteger)index didSave:(DidSaveBlock)saveBlock;
+
+/*
+ * @param imageView    点击的imageView
+ * @param URLStrings   加载的网络图片的urlString
+ * @param image        占位图片
+ * @param index        点击的图片在所有要展示图片中的位置
+ * @param dismiss      photo保存到m相册的回调
+ * @param dismiss      photoBrowser消失的回调
+ */
++ (nonnull instancetype)showFromImageView:(nullable UIImageView *)imageView withURLStrings:(nullable NSArray *)URLStrings placeholderImage:(nullable UIImage *)image atIndex:(NSInteger)index didSave:(DidSaveBlock)saveBlock dismiss:(DismissBlock)block;
+
+/*
+ * @param imageView    点击的imageView
+ * @param withImages   加载的本地图片
+ * @param image        占位图片
+ * @param index        点击的图片在所有要展示图片中的位置
+ * @param didSave      photo保存到m相册的回调
+ * @param dismiss      photoBrowser消失的回调
+ */
++ (nonnull instancetype)showFromImageView:(nullable UIImageView *)imageView withImages:(nullable NSArray *)images atIndex:(NSInteger)index didSave:(DidSaveBlock)saveBlock dismiss:(DismissBlock)block;
+
+
+
 @property (nonatomic, strong, nullable) UIImage *placeholderImage;
+
+/*
+ * 保存到相册回调
+ */
+@property (nonatomic, copy) DidSaveBlock didSaveBlock;
+
+/*
+ * 长按图片回调
+ */
+@property (nonatomic, copy) LongTapBlock longTapBlock;
+
+
+/*
+ * 是否隐藏保存按钮，默认不隐藏
+ */
+@property (nonatomic) BOOL didHideSaveButton;
 
 @end

--- a/HUPhotoBrowser/HUPhotoBrowserCell.h
+++ b/HUPhotoBrowser/HUPhotoBrowserCell.h
@@ -29,4 +29,6 @@ static NSString * const kPhotoCellDidImageLoadedNotification = @"kPhotoCellDidIm
 
 @property (nonatomic, copy) void(^tapActionBlock)(UITapGestureRecognizer *tapGesture);
 
+@property (nonatomic, copy) void(^longActionBlock)(UILongPressGestureRecognizer *longGesture);
+
 @end

--- a/HUPhotoBrowser/HUPhotoBrowserCell.m
+++ b/HUPhotoBrowser/HUPhotoBrowserCell.m
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic,strong) UITapGestureRecognizer *doubleTap;
 @property (nonatomic,strong) UITapGestureRecognizer *singleTap;
+@property (nonatomic,strong) UILongPressGestureRecognizer *longTap;
 
 @end
 
@@ -29,6 +30,7 @@
         [self setupView];
         [self addGestureRecognizer:self.singleTap];
         [self addGestureRecognizer:self.doubleTap];
+        [self addGestureRecognizer:self.longTap];
     }
     return self;
 }
@@ -110,6 +112,13 @@
     
 }
 
+- (void)longTapGestrueHandle:(UILongPressGestureRecognizer *)sender {
+    if (self.longActionBlock) {
+        self.longActionBlock(sender);
+    }
+    
+}
+
 #pragma mark - private
 
 - (CGRect)zoomRectForScale:(float)scale withCenter:(CGPoint)center {
@@ -181,6 +190,15 @@
         [_singleTap requireGestureRecognizerToFail:self.doubleTap];
     }
     return _singleTap;
+}
+
+- (UILongPressGestureRecognizer *)longTap {
+    if (!_longTap) {
+        _longTap = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longTapGestrueHandle:)];
+        _longTap.numberOfTouchesRequired = 1;
+        [_longTap requireGestureRecognizerToFail:self.singleTap];
+    }
+    return _longTap;
 }
 
 @end


### PR DESCRIPTION
【大改进】
1.增加了隐藏【保存】按钮属性didHideSaveButton。
2.移除SVProgressHUD提示，增加保存回调didSaveBlock；这样做使得库更加灵活，不再受限于第三方库影响。
3.增加长按图片回调LongTapBlock；这样做可以更加灵活得自定义功能。

其它没有实现的想法：
tool可以设置底部或顶部，没有保存按钮时文字居中。
更多功能，慢慢补充。。

【技巧】
隐藏保存按钮，使用长按回调，再自定义一个UIActionSheet，就可以做到像微信预览图片一样的功能。

本人是使用Swift的
例子1：
let browser = HUPhotoBrowser.show(from: imageViwe, withURLStrings: ["http://image1","https://image2"], at: 0)
        browser.didHideSaveButton = true
        browser.longTapBlock = {(image,index,longGesture) in
            let ac = UIActionSheet(title: "提示", delegate: self, cancelButtonTitle: "取消", destructiveButtonTitle: "保存到相册", otherButtonTitles: "分享给好友", nil)
            ac.show()
}

例子2：
HUPhotoBrowser.show(from: imageViwe, withURLStrings: ["http://image1","https://image2"], placeholderImage: placeholderImage, at: 0) { (image, error, info) in
            if(error == nil){
                //提示成功
            }else{
                //提示失败
            }
}